### PR TITLE
Allow configPath and buildApp command options

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -5,17 +5,22 @@ const path = require('path');
 module.exports = {
   name: 'bundlesize:test',
   description: 'Assert that your app\'s bundle size is within its defined limits',
-
-  availableOptions: [],
   works: 'insideProject',
 
-  run() {
+  availableOptions: [
+    { name: 'config-path', type: String, default: 'config/bundlesize.js' },
+    { name: 'build-app', type: Boolean, default: true }
+  ],
+
+  run(options) {
     let BundlesizeTestTask = require('../tasks/test');
 
     let testTask = new BundlesizeTestTask({
       ui: this.ui,
       rootDir: this.project.root,
-      buildDir: path.join(this.project.root, 'dist')
+      buildDir: path.join(this.project.root, 'dist'),
+      configPath: options.configPath,
+      buildApp: options.buildApp
     });
 
     return testTask.run();

--- a/lib/tasks/test.js
+++ b/lib/tasks/test.js
@@ -7,12 +7,6 @@ const chalk = require('chalk');
 const emberBuild = require('../helpers/ember-build');
 const assertBundlesize = require('../helpers/assert-bundlesize');
 
-const CONFIG_PATH = 'config/bundlesize.js';
-
-function hasBuild() {
-  return true;
-}
-
 module.exports = class BundlesizeTestTask {
 
   constructor(options) {
@@ -23,12 +17,11 @@ module.exports = class BundlesizeTestTask {
     let errors = 0;
     return Promise.resolve()
       .then(() => {
-        if (this.skipBuildIfAvailable && hasBuild()) {
-          return;
+        if (this.buildApp) {
+          this.ui.startProgress('Building for production...');
+          return emberBuild()
+            .then(() => this.ui.stopProgress());
         }
-        this.ui.startProgress('Building for production...');
-        return emberBuild()
-          .then(() => this.ui.stopProgress());
       })
       .then(() => {
         let config = this.getConfig();
@@ -58,9 +51,9 @@ module.exports = class BundlesizeTestTask {
   }
 
   getConfig() {
-    let configPath = path.join(this.rootDir, CONFIG_PATH);
+    let configPath = path.join(this.rootDir, this.configPath);
     if (!fs.existsSync(configPath)) {
-      throw new SilentError('Config file `config/bundlesize.js` not found. Please run `ember generate ember-cli-bundlesize` to generate a default config');
+      throw new SilentError(`Config file '${this.configPath}' not found. Please run 'ember generate ember-cli-bundlesize' to generate a default config`);
     }
     return require(configPath);
   }

--- a/node-tests/tasks/test-test.js
+++ b/node-tests/tasks/test-test.js
@@ -45,7 +45,8 @@ describe('bundlesize:test', function() {
       ui,
       rootDir,
       buildDir,
-      skipBuildIfAvailable: true
+      buildApp: false,
+      configPath: 'config/bundlesize.js'
     });
   });
 


### PR DESCRIPTION
Allow the configPath to be changed just like how ember-try does it (ie: ember bundlesize:test --config-path="ember-config/bundlesize.js"). Also allow the building of the app to be disabled for cases where you do not want to trigger a whole new build.